### PR TITLE
Update README.md - setup not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 ## Modules
 
 * [cheatsheet](cheatsheet/) - show cheatsheet for the frontmost application's menu
-* [dock_press](dock_press/) - bind hotkeys to numbered dock items,
-  requires [hs._asm.axuielement](https://github.com/asmagill/hs._asm.axuielement/)
+* [dock_press](dock_press/) - bind hotkeys to numbered dock items
 * [ensure](ensure/) - request confirmation for application hotkeys
 * [layout_cache](layout_cache/) - cache keyboard layout per window
 


### PR DESCRIPTION
as of d64e94267d3296385693386f5cd0733ca1f47dbc (switch from hs._asm.axuielement to hs.axuielement) this setup is not required anymore